### PR TITLE
Fix audio head dropping

### DIFF
--- a/packages/delir-core/src/Engine/Engine.ts
+++ b/packages/delir-core/src/Engine/Engine.ts
@@ -32,6 +32,7 @@ interface RenderingOption {
     loop: boolean
     ignoreMissingEffect: boolean
     realtime: boolean
+    audioBufferSizeSecond: number
 }
 
 interface RenderProgression {
@@ -94,6 +95,7 @@ export default class Engine {
                 ignoreMissingEffect: false,
                 loop: false,
                 realtime: false,
+                audioBufferSizeSecond: 1,
             }
 
             const request = this._initStage(compositionId, renderingOption)
@@ -131,6 +133,7 @@ export default class Engine {
             endFrame: -1,
             ignoreMissingEffect: false,
             realtime: false,
+            audioBufferSizeSecond: 1,
         })
 
         this.stopCurrentRendering()
@@ -161,7 +164,7 @@ export default class Engine {
                 const lastFrame = context.rootComposition.durationFrames
                 let animationFrameId: number
                 let renderedFrames = 0
-                let lastAudioBufferTime = -1
+                let lastAudioBufferTime = -1 * renderingOption.audioBufferSizeSecond
 
                 const throttle = options.realtime
                     ? (fn: () => void) => _.throttle(fn, 1000 / context.framerate)
@@ -177,9 +180,11 @@ export default class Engine {
                     const currentFrame = renderingOption.beginFrame + renderedFrames
                     const currentTime = currentFrame / framerate
 
-                    // 最後のバッファリングから１秒経過 & 次のフレームがレンダリングの終わりでなければバッファリング
+                    // 最後のバッファリングからバッファサイズ分経過 & 次のフレームがレンダリングの終わりでなければバッファリング
                     const isAudioBufferingNeeded =
-                        lastAudioBufferTime !== (currentTime | 0) && renderedFrames + 1 <= context.durationFrames
+                        lastAudioBufferTime === -1 ||
+                        (currentTime - lastAudioBufferTime >= renderingOption.audioBufferSizeSecond &&
+                            renderedFrames + 1 <= context.durationFrames)
 
                     if (isAudioBufferingNeeded) {
                         lastAudioBufferTime = currentTime | 0
@@ -283,17 +288,17 @@ export default class Engine {
         canvas.height = rootComposition.height
 
         const compositionDurationTime = rootComposition.durationFrames / rootComposition.framerate
-        const bufferSizeBytePerSec = rootComposition.samplingRate * 4 /* bytes */
+        const audioBufferSizeByte = rootComposition.samplingRate * option.audioBufferSizeSecond * 4
 
         const audioContext = new OfflineAudioContext(
             rootComposition.audioChannels,
-            Math.ceil(bufferSizeBytePerSec * compositionDurationTime),
+            Math.ceil(audioBufferSizeByte * compositionDurationTime),
             rootComposition.samplingRate,
         )
 
         const audioBuffers = _.times(
             rootComposition.audioChannels,
-            () => new Float32Array(new ArrayBuffer(bufferSizeBytePerSec)),
+            () => new Float32Array(new ArrayBuffer(audioBufferSizeByte)),
         )
 
         const currentFrame = option.beginFrame
@@ -315,7 +320,7 @@ export default class Engine {
             destAudioBuffer: audioBuffers,
             audioContext,
             samplingRate: rootComposition.samplingRate,
-            neededSamples: rootComposition.samplingRate,
+            neededSamples: rootComposition.samplingRate * option.audioBufferSizeSecond,
             audioChannels: rootComposition.audioChannels,
             isAudioBufferingNeeded: false,
 
@@ -397,8 +402,8 @@ export default class Engine {
         destBufferCtx.fillStyle = context.rootComposition.backgroundColor.toString()
         destBufferCtx.fillRect(0, 0, context.width, context.height)
 
-        const channelAudioBuffers = _.times(context.rootComposition.audioChannels, () => {
-            return new Float32Array(new ArrayBuffer(4 /* bytes */ * context.rootComposition.samplingRate))
+        const clipAudioBuffers = _.times(context.rootComposition.audioChannels, () => {
+            return new Float32Array(new ArrayBuffer(context.neededSamples * 4))
         })
 
         for (const layerTask of layerRenderTasks) {
@@ -432,7 +437,7 @@ export default class Engine {
 
                     srcCanvas: clipTask.rendererType === 'adjustment' ? destBufferCanvas : null,
                     destCanvas: clipBufferCanvas,
-                    destAudioBuffer: channelAudioBuffers,
+                    destAudioBuffer: clipAudioBuffers,
                 })
 
                 // Lookup before apply expression referenceable effect params expression
@@ -505,12 +510,12 @@ export default class Engine {
                 if (context.isAudioBufferingNeeded) {
                     await mergeAudioBufferInto(
                         context.destAudioBuffer,
-                        channelAudioBuffers,
+                        clipAudioBuffers,
                         context.audioChannels,
                         context.samplingRate,
                     )
 
-                    for (const chBuffer of channelAudioBuffers) {
+                    for (const chBuffer of clipAudioBuffers) {
                         chBuffer.fill(0)
                     }
                 }

--- a/packages/delir-core/src/Engine/Engine.ts
+++ b/packages/delir-core/src/Engine/Engine.ts
@@ -1,3 +1,6 @@
+import * as _ from 'lodash'
+import * as timecodes from 'node-timecodes'
+
 import { Clip, Effect, Project } from '../Entity'
 import EffectPluginBase from '../PluginSupport/PostEffectBase'
 import { ParameterValueTypes } from '../PluginSupport/type-descriptor'
@@ -7,9 +10,6 @@ import { IRenderer } from './Renderer/RendererBase'
 
 import PluginRegistry from '../PluginSupport/plugin-registry'
 
-import WebGLContext from '@ragg/delir-core/src/Engine/WebGL/WebGLContext'
-import * as _ from 'lodash'
-import * as timecodes from 'node-timecodes'
 import { EffectPluginMissingException, RenderingAbortedException, RenderingFailedException } from '../Exceptions/'
 import { mergeInto as mergeAudioBufferInto } from '../helper/Audio'
 import defaults from '../helper/defaults'
@@ -21,6 +21,7 @@ import { RenderContextBase } from './RenderContext/RenderContextBase'
 import ClipRenderTask from './Task/ClipRenderTask'
 import EffectRenderTask from './Task/EffectRenderTask'
 import { LayerRenderTask } from './Task/LayerRenderTask'
+import WebGLContext from './WebGL/WebGLContext'
 
 export interface ExpressionExecuters {
     [paramName: string]: (exposes: ExpressionContext.ContextSource) => ParameterValueTypes

--- a/packages/delir-core/src/Engine/RenderContext/ClipRenderContext.ts
+++ b/packages/delir-core/src/Engine/RenderContext/ClipRenderContext.ts
@@ -8,7 +8,7 @@ export interface ClipRenderContext<T extends { [paramName: string]: any }>
         ClipRenderContextAttributes<T> {}
 
 export interface ClipRenderContextAttributes<T extends RealParameterValues> {
-    clip: Clip
+    clip: Readonly<Clip>
     parameters: T
     clipEffectParams: ReferenceableEffectsParams
 

--- a/packages/delir-core/src/Engine/Task/LayerRenderTask.ts
+++ b/packages/delir-core/src/Engine/Task/LayerRenderTask.ts
@@ -13,20 +13,20 @@ export class LayerRenderTask {
     public clipRenderTasks: ClipRenderTask[]
 
     public findRenderTargetClipTasks(context: RenderContextBase) {
-        const audioBufferingSizeTime = context.neededSamples / context.samplingRate
-        const audioRenderStartRangeFrame = audioBufferingSizeTime * context.framerate
+        const audioBufferSizeTime = context.neededSamples / context.samplingRate
+        const audioBufferRangeFrame = audioBufferSizeTime * context.framerate
 
         return this.clipRenderTasks.filter(clip => {
             if (context.isAudioBufferingNeeded && clip.rendererType === 'audio') {
                 return (
-                    clip.clipPlacedFrame <= context.frameOnComposition + audioRenderStartRangeFrame &&
-                    clip.clipPlacedFrame + clip.clipDurationFrames >= context.frameOnComposition
+                    clip.clipPlacedFrame <= context.frameOnComposition + audioBufferRangeFrame - 1 &&
+                    clip.clipPlacedFrame + clip.clipDurationFrames > context.frameOnComposition
                 )
             }
 
             return (
                 clip.clipPlacedFrame <= context.frameOnComposition &&
-                clip.clipPlacedFrame + clip.clipDurationFrames >= context.frameOnComposition
+                clip.clipPlacedFrame + clip.clipDurationFrames > context.frameOnComposition
             )
         })
     }

--- a/packages/delir-core/src/Engine/renderer/Audio/Audio.ts
+++ b/packages/delir-core/src/Engine/renderer/Audio/Audio.ts
@@ -102,6 +102,12 @@ export default class AudioRenderer implements IRenderer<AudioRendererParam> {
         const offsetTimeInBuffer = (context.clip.placedFrame / context.framerate) % bufferSizeTime
         const startInBufferOffsetSamples = Math.floor(offsetTimeInBuffer * context.samplingRate)
 
+        // Cutting position
+        const clipEndTime = (context.clip.placedFrame + context.clip.durationFrames) / context.framerate
+        const isClipEnd = clipEndTime < context.timeOnComposition + bufferSizeTime
+        const clipEndTimeInBuffer = clipEndTime % bufferSizeTime
+        const clipEndPosSamples = Math.floor(clipEndTimeInBuffer * context.samplingRate)
+
         // Slice position
         const startTimeSamples = Math.max(0, context.parameters.startTime) * context.samplingRate
         const elapsedSamples = Math.round(context.timeOnClip * context.samplingRate)
@@ -125,6 +131,10 @@ export default class AudioRenderer implements IRenderer<AudioRendererParam> {
 
             if (isClipHead) {
                 slices[ch] = slices[ch].fill(0, 0, startInBufferOffsetSamples) // Fill rewinded samples
+            }
+
+            if (isClipEnd) {
+                slices[ch].fill(0, clipEndPosSamples)
             }
         }
 

--- a/packages/delir/utils/Dev/ExampleProject1/index.ts
+++ b/packages/delir/utils/Dev/ExampleProject1/index.ts
@@ -17,7 +17,7 @@ const videoAsset = new Delir.Entity.Asset({
 const audioAsset = new Delir.Entity.Asset({
     name: 'Audio',
     fileType: 'mp3',
-    path: join(dirname, 'audio.mp3'),
+    path: join(dirname, 'Infosphere_Guardians.mp3'),
 })
 
 const imageAsset = new Delir.Entity.Asset({
@@ -106,7 +106,7 @@ const textClip = assign(
 const audioClip = assign(
     new Delir.Entity.Clip({
         renderer: 'audio',
-        placedFrame: 0,
+        placedFrame: 15,
         durationFrames,
     }),
     {
@@ -114,6 +114,12 @@ const audioClip = assign(
             source: [
                 new Delir.Entity.Keyframe({
                     value: { assetId: audioAsset.id },
+                    frameOnClip: 0,
+                }),
+            ],
+            startTime: [
+                new Delir.Entity.Keyframe({
+                    value: 33,
                     frameOnClip: 0,
                 }),
             ],
@@ -263,6 +269,7 @@ const videoClip = assign(
 
 layer1.addClip(adjustmentClip)
 layer2.addClip(textClip)
+layer3.addClip(audioClip)
 layer4.addClip(p5jsClip)
 layer5.addClip(videoClip)
 

--- a/packages/deream/index.ts
+++ b/packages/deream/index.ts
@@ -130,6 +130,7 @@ export default async (options: ExportOptions): Promise<void> => {
         loop: false,
         ignoreMissingEffect: options.ignoreMissingEffect,
         realtime: false,
+        audioBufferSizeSecond: 1,
     })
     // await queue.waitEmpty()
 


### PR DESCRIPTION
Ticket: https://trello.com/c/WqSSpzp4/178-fix-audio-head-dropping

Has breaking changes to public API?: No

#### Annotation to release
- Audioクリップの先頭の音が切れる事があった不具合を修正
- Audioクリップの終わりの音が、クリップの終わった後まで残る不具合を修正

#### Breaking changes (In delir-core Public API or Expression/p5.js intergration API)
- AudioクリップのstartTimeが0以下の値を無視するようになった
