### PR TITLE
Fix scroll reset in later frame position & improve Timeline performance

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -216,6 +216,11 @@ export function compileRendererJs(done) {
             resolve: {
                 extensions: ['.js', '.jsx', '.ts', '.tsx'],
                 modules: ['node_modules'],
+                alias: {
+                    // Disable React development build for performance measurement
+                    react: 'react/cjs/react.production.min.js',
+                    'react-dom': 'react-dom/cjs/react-dom.production.min.js',
+                },
             },
             module: {
                 rules: [

--- a/packages/delir/components/ContextMenu/ContextMenu.tsx
+++ b/packages/delir/components/ContextMenu/ContextMenu.tsx
@@ -101,6 +101,6 @@ export class ContextMenu extends React.Component<ContextMenuProps> {
 
     public render() {
         const Element = this.props.elementType!
-        return <Element ref={this.root} style={{ display: 'none' }} />
+        return <Element {...{ ref: this.root, style: { display: 'none' } } as any} />
     }
 }

--- a/packages/delir/components/dropdown.tsx
+++ b/packages/delir/components/dropdown.tsx
@@ -9,6 +9,7 @@ import * as s from './dropdown.styl'
 interface Props {
     shownInitial?: boolean
     className?: string
+    children?: React.ReactNode
 }
 
 interface State {
@@ -53,6 +54,11 @@ export default class Dropdown extends PureComponent<Props, State> {
             capture: true,
         })
         this._portal.unmount()
+    }
+
+    public shouldComponentUpdate(nextProps: Props, nextState: State) {
+        const { props, state } = this
+        return props.className !== nextProps.className || state.show !== nextState.show
     }
 
     public componentDidUpdate() {

--- a/packages/delir/domain/Editor/EditorStore.ts
+++ b/packages/delir/domain/Editor/EditorStore.ts
@@ -22,7 +22,6 @@ export interface EditorState {
     activeParam: ParameterTarget | null
     dragEntity: DragEntity | null
     processingState: string | null
-    previewPlayed: boolean
     currentPreviewFrame: number
     preferenceOpened: boolean
     clipboard: ClipboardEntry | null
@@ -40,7 +39,6 @@ export default class EditorStore extends Store<EditorState> {
         activeParam: null,
         dragEntity: null,
         processingState: null,
-        previewPlayed: false,
         currentPreviewFrame: 0,
         preferenceOpened: false,
         clipboard: null,
@@ -161,14 +159,6 @@ export default class EditorStore extends Store<EditorState> {
         this.updateWith(d => (d.processingState = payload.stateText))
     })
 
-    private handlestartPreview = listen(EditorActions.startPreviewAction, () => {
-        this.updateWith(d => (d.previewPlayed = true))
-    })
-
-    private handlestopPreview = listen(EditorActions.stopPreviewAction, () => {
-        this.updateWith(d => (d.previewPlayed = false))
-    })
-
     private handleseekPreviewFrame = listen(EditorActions.seekPreviewFrameAction, payload => {
         this.updateWith(d => (d.currentPreviewFrame = Math.round(payload.frame)))
     })
@@ -199,6 +189,10 @@ export default class EditorStore extends Store<EditorState> {
     private handleSetClipboardEntry = listen(EditorActions.setClipboardEntry, payload => {
         this.updateWith(draft => (draft.clipboard = payload.entry))
     })
+
+    public get currentPreviewFrame() {
+        return this.state.currentPreviewFrame
+    }
 
     public getActiveParam() {
         return this.state.activeParam

--- a/packages/delir/domain/Editor/EditorStore.ts
+++ b/packages/delir/domain/Editor/EditorStore.ts
@@ -190,7 +190,7 @@ export default class EditorStore extends Store<EditorState> {
         this.updateWith(draft => (draft.clipboard = payload.entry))
     })
 
-    public get currentPreviewFrame() {
+    public get currentPointFrame() {
         return this.state.currentPreviewFrame
     }
 
@@ -198,8 +198,21 @@ export default class EditorStore extends Store<EditorState> {
         return this.state.activeParam
     }
 
+    public get activeComp() {
+        return this.state.activeComp ? { ...this.state.activeComp } : null
+    }
+
+    public get activeClip() {
+        return this.state.activeClip ? { ...this.state.activeClip } : null
+    }
+
+    public get dragEntity() {
+        return this.state.dragEntity
+    }
+
+    /** @deprecated */
     public getActiveComposition() {
-        return this.state.activeComp
+        return this.state.activeComp ? { ...this.state.activeComp } : null
     }
 
     public getClipboardEntry() {

--- a/packages/delir/domain/Editor/actions.ts
+++ b/packages/delir/domain/Editor/actions.ts
@@ -15,12 +15,6 @@ export const EditorActions = actions('Editor', {
     changeActiveCompositionAction: action<{ compositionId: string }>(),
     changeActiveClipAction: action<{ clipId: string }>(),
     changeActiveParamAction: action<{ target: ParameterTarget | null }>(),
-    startPreviewAction: action<{
-        compositionId: string
-        beginFrame: number
-        ignoreMissingEffect: boolean
-    }>(),
-    stopPreviewAction: action<{}>(),
     renderDestinateAction: action<{
         compositionId: string
         ignoreMissingEffect: boolean

--- a/packages/delir/domain/Editor/operations.ts
+++ b/packages/delir/domain/Editor/operations.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs-extra'
 import * as _ from 'lodash'
 import * as MsgPack from 'msgpack5'
 import * as path from 'path'
+import { SpreadType } from '../../utils/Spread'
 
 import PreferenceStore from '../Preference/PreferenceStore'
 import RendererStore from '../Renderer/RendererStore'
@@ -256,7 +257,7 @@ export const copyEntity = operation(
             entity,
         }: {
             type: ClipboardEntry['type']
-            entity: Delir.Entity.Clip
+            entity: SpreadType<Delir.Entity.Clip>
         },
     ) => {
         context.dispatch(EditorActions.setClipboardEntry, {

--- a/packages/delir/domain/Editor/operations.ts
+++ b/packages/delir/domain/Editor/operations.ts
@@ -102,25 +102,6 @@ export const changeActiveParam = operation((context, { target }: { target: Param
     context.dispatch(EditorActions.changeActiveParamAction, { target })
 })
 
-//
-// Preview
-//
-export const startPreview = operation(
-    (context, { compositionId, beginFrame = 0 }: { compositionId: string; beginFrame?: number }) => {
-        const preference = context.getStore(PreferenceStore).getPreferences()
-
-        context.dispatch(EditorActions.startPreviewAction, {
-            compositionId,
-            beginFrame,
-            ignoreMissingEffect: preference.renderer.ignoreMissingEffect,
-        })
-    },
-)
-
-export const stopPreview = operation(context => {
-    context.dispatch(EditorActions.stopPreviewAction, {})
-})
-
 export const renderDestinate = operation((context, arg: { compositionId: string }) => {
     const preference = context.getStore(PreferenceStore).getPreferences()
 

--- a/packages/delir/domain/Editor/operations.ts
+++ b/packages/delir/domain/Editor/operations.ts
@@ -16,7 +16,7 @@ import t from './operations.i18n'
 import { ClipboardEntry, ParameterTarget } from './types'
 
 export type DragEntity =
-    | { type: 'asset'; asset: SpreadType<Delir.Entity.Asset> }
+    | { type: 'asset'; asset: Delir.Entity.Asset }
     | { type: 'clip'; clip: SpreadType<Delir.Entity.Clip> }
     | { type: 'clip-resizing'; clip: SpreadType<Delir.Entity.Clip> }
 

--- a/packages/delir/domain/Editor/operations.ts
+++ b/packages/delir/domain/Editor/operations.ts
@@ -16,9 +16,9 @@ import t from './operations.i18n'
 import { ClipboardEntry, ParameterTarget } from './types'
 
 export type DragEntity =
-    | { type: 'asset'; asset: Delir.Entity.Asset }
-    | { type: 'clip'; clip: Delir.Entity.Clip }
-    | { type: 'clip-resizing'; clip: Delir.Entity.Clip }
+    | { type: 'asset'; asset: SpreadType<Delir.Entity.Asset> }
+    | { type: 'clip'; clip: SpreadType<Delir.Entity.Clip> }
+    | { type: 'clip-resizing'; clip: SpreadType<Delir.Entity.Clip> }
 
 //
 // App services

--- a/packages/delir/domain/Project/ProjectStore.ts
+++ b/packages/delir/domain/Project/ProjectStore.ts
@@ -45,7 +45,7 @@ export default class ProjectStore extends Store<ProjectStoreState> {
 
     private handleAddLayerWithAsset = listen(
         ProjectActions.addLayerWithAssetAction,
-        ({ targetComposition, clip, asset, layer }) => {
+        ({ targetCompositionId, clip, asset, layer }) => {
             const { project } = this.state
             const paramName = Delir.Engine.Renderers.getInfo(clip.renderer).assetAssignMap[asset.fileType]
 
@@ -58,7 +58,7 @@ export default class ProjectStore extends Store<ProjectStoreState> {
 
             clip.addKeyframe(paramName, keyframe)
             layer.addClip(clip)
-            project!.findComposition(targetComposition.id)!.addLayer(layer)
+            project!.findComposition(targetCompositionId)!.addLayer(layer)
             this.updateLastModified()
         },
     )

--- a/packages/delir/domain/Project/actions.ts
+++ b/packages/delir/domain/Project/actions.ts
@@ -15,7 +15,7 @@ export const ProjectActions = actions('Project', {
         index: number
     }>(),
     addLayerWithAssetAction: action<{
-        targetComposition: Delir.Entity.Composition
+        targetCompositionId: string
         layer: Delir.Entity.Layer
         clip: Delir.Entity.Clip
         asset: Delir.Entity.Asset

--- a/packages/delir/domain/Project/operations.ts
+++ b/packages/delir/domain/Project/operations.ts
@@ -3,6 +3,7 @@ import { operation } from '@ragg/fleur'
 import * as _ from 'lodash'
 import * as uuid from 'uuid'
 import { safeAssign } from '../../utils/safeAssign'
+import { SpreadType } from '../../utils/Spread'
 
 import EditorStore from '../Editor/EditorStore'
 import * as EditorOps from '../Editor/operations'
@@ -103,7 +104,7 @@ export const addLayerWithAsset = operation(
             index = 0,
             asset,
         }: {
-            targetComposition: Delir.Entity.Composition
+            targetComposition: SpreadType<Delir.Entity.Composition>
             index?: 0
             asset: Delir.Entity.Asset
         },
@@ -154,7 +155,7 @@ export const addLayerWithAsset = operation(
         })
 
         context.dispatch(ProjectActions.addLayerWithAssetAction, {
-            targetComposition,
+            targetCompositionId: targetComposition.id,
             clip,
             asset,
             layer,

--- a/packages/delir/domain/Renderer/actions.ts
+++ b/packages/delir/domain/Renderer/actions.ts
@@ -3,4 +3,6 @@ import { action, actions } from '@ragg/fleur'
 export const RendererActions = actions('Renderer', {
     addPlugins: action<{ plugins: any[] }>(),
     setPreviewCanvas: action<{ canvas: HTMLCanvasElement }>(),
+    startPreview: action<{ compositionId: string; beginFrame: number; ignoreMissingEffect: boolean }>(),
+    stopPreview: action<{}>(),
 })

--- a/packages/delir/domain/Renderer/operations.ts
+++ b/packages/delir/domain/Renderer/operations.ts
@@ -2,7 +2,9 @@ import { operation } from '@ragg/fleur'
 import { remote } from 'electron'
 import { join } from 'path'
 
+import EditorStore from '../Editor/EditorStore'
 import * as EditorOps from '../Editor/operations'
+import PreferenceStore from '../Preference/PreferenceStore'
 import { RendererActions } from './actions'
 import FSPluginLoader from './FSPluginLoader'
 
@@ -42,4 +44,21 @@ export const loadPlugins = operation(async context => {
 
 export const setPreviewCanvas = operation((context, arg: { canvas: HTMLCanvasElement }) => {
     context.dispatch(RendererActions.setPreviewCanvas, arg)
+})
+
+export const startPreview = operation(
+    (context, { compositionId, beginFrame }: { compositionId: string; beginFrame?: number }) => {
+        beginFrame = beginFrame != null ? beginFrame : context.getStore(EditorStore).currentPreviewFrame
+        const preference = context.getStore(PreferenceStore).getPreferences()
+
+        context.dispatch(RendererActions.startPreview, {
+            compositionId,
+            beginFrame,
+            ignoreMissingEffect: preference.renderer.ignoreMissingEffect,
+        })
+    },
+)
+
+export const stopPreview = operation(context => {
+    context.dispatch(RendererActions.stopPreview, {})
 })

--- a/packages/delir/domain/Renderer/operations.ts
+++ b/packages/delir/domain/Renderer/operations.ts
@@ -48,7 +48,7 @@ export const setPreviewCanvas = operation((context, arg: { canvas: HTMLCanvasEle
 
 export const startPreview = operation(
     (context, { compositionId, beginFrame }: { compositionId: string; beginFrame?: number }) => {
-        beginFrame = beginFrame != null ? beginFrame : context.getStore(EditorStore).currentPreviewFrame
+        beginFrame = beginFrame != null ? beginFrame : context.getStore(EditorStore).currentPointFrame
         const preference = context.getStore(PreferenceStore).getPreferences()
 
         context.dispatch(RendererActions.startPreview, {

--- a/packages/delir/package.json
+++ b/packages/delir/package.json
@@ -31,7 +31,7 @@
     "@ragg/delir-core": "*",
     "@ragg/deream": "*",
     "@ragg/fleur": "0.0.12",
-    "@ragg/fleur-react": "0.0.11",
+    "@ragg/fleur-react": "0.0.12",
     "classnames": "2.2.6",
     "form-serialize": "0.7.2",
     "fs-extra": "7.0.1",

--- a/packages/delir/utils/Spread.ts
+++ b/packages/delir/utils/Spread.ts
@@ -1,0 +1,8 @@
+class A {
+    public a: number
+    public c: string
+    public b() {}
+}
+
+type RemoveMethodKeys<T> = { [K in keyof T]: T[K] extends (...args: any[]) => any ? never : K }[keyof T]
+export type SpreadType<T extends object> = Pick<T, RemoveMethodKeys<T>>

--- a/packages/delir/views/AppView/AppView.tsx
+++ b/packages/delir/views/AppView/AppView.tsx
@@ -33,7 +33,7 @@ const mapStoresToProps = (getStore: StoreGetter) => ({
 })
 
 export default withComponentContext(
-    connectToStores([RendererStore], mapStoresToProps)(
+    connectToStores([EditorStore, RendererStore], mapStoresToProps)(
         class AppView extends React.PureComponent<Props> {
             public root = React.createRef<HTMLDivElement>()
             public trap: InstanceType<typeof Mousetrap>

--- a/packages/delir/views/KeyframeEditor/KeyframeEditor.tsx
+++ b/packages/delir/views/KeyframeEditor/KeyframeEditor.tsx
@@ -5,6 +5,7 @@ import { clipboard } from 'electron'
 import * as _ from 'lodash'
 import * as mouseWheel from 'mouse-wheel'
 import * as React from 'react'
+import { SpreadType } from '../../utils/Spread'
 import { MeasurePoint } from '../../utils/TimePixelConversion'
 
 import * as EditorOps from '../../domain/Editor/operations'
@@ -34,8 +35,8 @@ export interface EditorResult {
 }
 
 interface OwnProps {
-    activeComposition: Delir.Entity.Composition | null
-    activeClip: Delir.Entity.Clip | null
+    activeComposition: SpreadType<Delir.Entity.Composition> | null
+    activeClip: SpreadType<Delir.Entity.Clip> | null
     scrollLeft: number
     scale: number
     pxPerSec: number
@@ -542,7 +543,7 @@ export default withComponentContext(
                 return activeClip ? Delir.Engine.Renderers.getInfo(activeClip.renderer).parameter.properties || [] : []
             }
 
-            private get activeEntityObject(): Delir.Entity.Clip | Delir.Entity.Effect | null {
+            private get activeEntityObject(): SpreadType<Delir.Entity.Clip> | SpreadType<Delir.Entity.Effect> | null {
                 const { activeClip, activeParam } = this.props
 
                 if (activeClip) {

--- a/packages/delir/views/KeyframeEditor/KeyframeEditor.tsx
+++ b/packages/delir/views/KeyframeEditor/KeyframeEditor.tsx
@@ -797,17 +797,21 @@ export default withComponentContext(
 
             private _getDescriptorByParamName(paramName: string | null) {
                 const rendererStore = this.props.context.getStore(RendererStore)
+                const { activeParam } = this.props
                 const activeEntityObject = this.activeEntityObject
 
-                if (!activeEntityObject) return null
+                if (!activeEntityObject || !activeParam) return null
 
                 let parameters: Delir.AnyParameterTypeDescriptor[]
 
-                if (activeEntityObject instanceof Delir.Entity.Clip) {
-                    const info = Delir.Engine.Renderers.getInfo(activeEntityObject.renderer)
+                if (activeParam.type === 'clip') {
+                    const info = Delir.Engine.Renderers.getInfo((activeEntityObject as Delir.Entity.Clip).renderer)
                     parameters = info ? info.parameter.properties : []
-                } else if (activeEntityObject instanceof Delir.Entity.Effect) {
-                    parameters = rendererStore.getPostEffectParametersById(activeEntityObject.processor) || []
+                } else if (activeParam.type === 'effect') {
+                    parameters =
+                        rendererStore.getPostEffectParametersById(
+                            (activeEntityObject as Delir.Entity.Effect).processor,
+                        ) || []
                 } else {
                     throw new Error('Unexpected entity type')
                 }

--- a/packages/delir/views/KeyframeEditor/KeyframeGraph.tsx
+++ b/packages/delir/views/KeyframeEditor/KeyframeGraph.tsx
@@ -2,7 +2,7 @@ import * as Delir from '@ragg/delir-core'
 import * as classnames from 'classnames'
 import * as _ from 'lodash'
 import * as React from 'react'
-
+import { SpreadType } from '../../utils/Spread'
 import TimePixelConversion from '../../utils/TimePixelConversion'
 
 import * as EditorOps from '../../domain/Editor/operations'
@@ -15,9 +15,9 @@ interface OwnProps {
     height: number
     viewBox: string
     scrollLeft: number
-    composition: Delir.Entity.Composition
-    parentClip: Delir.Entity.Clip
-    entity: Delir.Entity.Clip | Delir.Entity.Effect | null
+    composition: SpreadType<Delir.Entity.Composition>
+    parentClip: SpreadType<Delir.Entity.Clip>
+    entity: SpreadType<Delir.Entity.Clip> | SpreadType<Delir.Entity.Effect> | null
     paramName: string
     descriptor: Delir.AnyParameterTypeDescriptor
     keyframes: ReadonlyArray<Delir.Entity.Keyframe>

--- a/packages/delir/views/Timeline/Clip.tsx
+++ b/packages/delir/views/Timeline/Clip.tsx
@@ -1,10 +1,10 @@
 import * as Delir from '@ragg/delir-core'
 import { ContextProp, withComponentContext } from '@ragg/fleur-react'
 import * as classnames from 'classnames'
+import * as _ from 'lodash'
 import * as React from 'react'
 import { DraggableEventHandler } from 'react-draggable'
 import { Rnd, RndResizeCallback } from 'react-rnd'
-import { isWindows } from '../../utils/platform'
 
 import { ContextMenu, MenuItem, MenuItemOption } from '../../components/ContextMenu/ContextMenu'
 import * as EditorOps from '../../domain/Editor/operations'
@@ -39,6 +39,11 @@ export default withComponentContext(
     class Clip extends React.Component<Props, State> {
         public state: State = {
             left: this.props.left,
+        }
+
+        public shouldComponentUpdate(nextProps: Props, nextState: State) {
+            const { props, state } = this
+            return !_.isEqual(props, nextProps) || !_.isEqual(state, nextState)
         }
 
         public componentDidUpdate(prevProps: Props) {

--- a/packages/delir/views/Timeline/Clip.tsx
+++ b/packages/delir/views/Timeline/Clip.tsx
@@ -5,6 +5,7 @@ import * as _ from 'lodash'
 import * as React from 'react'
 import { DraggableEventHandler } from 'react-draggable'
 import { Rnd, RndResizeCallback } from 'react-rnd'
+import { SpreadType } from '../../utils/Spread'
 
 import { ContextMenu, MenuItem, MenuItemOption } from '../../components/ContextMenu/ContextMenu'
 import * as EditorOps from '../../domain/Editor/operations'
@@ -15,7 +16,7 @@ import t from './Clip.i18n'
 import * as s from './Clip.styl'
 
 interface OwnProps {
-    clip: Delir.Entity.Clip
+    clip: SpreadType<Delir.Entity.Clip>
     left: number
     width: number
     active: boolean

--- a/packages/delir/views/Timeline/Gradations.tsx
+++ b/packages/delir/views/Timeline/Gradations.tsx
@@ -3,6 +3,7 @@ import { connectToStores, StoreGetter } from '@ragg/fleur-react'
 import * as classnames from 'classnames'
 import * as React from 'react'
 
+import { SpreadType } from '../../utils/Spread'
 import TimePixelConversion, { MeasurePoint } from '../../utils/TimePixelConversion'
 
 import RendererStore from '../../domain/Renderer/RendererStore'
@@ -16,7 +17,7 @@ interface OwnProps {
     currentFrame: number
     measures: MeasurePoint[]
     previewPlaying: boolean
-    activeComposition: Delir.Entity.Composition | null
+    activeComposition: SpreadType<Delir.Entity.Composition> | null
     cursorHeight: number
     scrollLeft: number
     scale: number

--- a/packages/delir/views/Timeline/Gradations.tsx
+++ b/packages/delir/views/Timeline/Gradations.tsx
@@ -1,20 +1,21 @@
 import * as Delir from '@ragg/delir-core'
-import { connectToStores } from '@ragg/fleur-react'
+import { connectToStores, StoreGetter } from '@ragg/fleur-react'
 import * as classnames from 'classnames'
 import * as React from 'react'
 
 import TimePixelConversion, { MeasurePoint } from '../../utils/TimePixelConversion'
 
+import RendererStore from '../../domain/Renderer/RendererStore'
+
 import { ContextMenu, MenuItem } from '../../components/ContextMenu/ContextMenu'
 
-import RendererStore, { RenderState } from '../../domain/Renderer/RendererStore'
 import t from './Gradations.i18n'
 import * as s from './Gradations.styl'
 
 interface OwnProps {
     currentFrame: number
     measures: MeasurePoint[]
-    previewPlayed: boolean
+    previewPlaying: boolean
     activeComposition: Delir.Entity.Composition | null
     cursorHeight: number
     scrollLeft: number
@@ -23,20 +24,18 @@ interface OwnProps {
     onSeeked: (frame: number) => any
 }
 
-interface ConnectedProps {
-    lastRenderState: RenderState | null
-}
-
-type Props = OwnProps & ConnectedProps
+type Props = OwnProps & ReturnType<typeof mapStoresToProps>
 
 interface GradationsState {
     left: number
     dragSeekEnabled: boolean
 }
 
-export default connectToStores([RendererStore], getStore => ({
+const mapStoresToProps = (getStore: StoreGetter) => ({
     lastRenderState: getStore(RendererStore).getLastRenderState(),
-}))(
+})
+
+export default connectToStores([RendererStore], mapStoresToProps)(
     class Gradations extends React.Component<Props, GradationsState> {
         public static defaultProps = {
             scrollLeft: 0,
@@ -101,10 +100,10 @@ export default connectToStores([RendererStore], getStore => ({
         }
 
         private _updateCursor = () => {
-            const { activeComposition, scrollLeft, scale, previewPlayed, currentFrame, lastRenderState } = this.props
+            const { activeComposition, scrollLeft, scale, previewPlaying, currentFrame, lastRenderState } = this.props
             const { cursor, measureLayer } = this.refs
 
-            const usingCurrentFrame = previewPlayed && lastRenderState ? lastRenderState.currentFrame : currentFrame
+            const usingCurrentFrame = previewPlaying && lastRenderState ? lastRenderState.currentFrame : currentFrame
 
             if (activeComposition) {
                 // Reactの仕組みを使うとrenderMeasureが走りまくってCPUがヤバいので

--- a/packages/delir/views/Timeline/Layer.styl
+++ b/packages/delir/views/Timeline/Layer.styl
@@ -1,6 +1,4 @@
 .Layer
-    position sticky
-    left 0
     border-bottom 1px solid rgba(#fff, .1)
 
     &:focus,

--- a/packages/delir/views/Timeline/Layer.styl
+++ b/packages/delir/views/Timeline/Layer.styl
@@ -8,6 +8,7 @@
 
 .clipsContainer
     position relative
+    box-sizing border-box
     display block
     height 24px
     padding 2px 0

--- a/packages/delir/views/Timeline/Layer.styl
+++ b/packages/delir/views/Timeline/Layer.styl
@@ -1,4 +1,5 @@
 .Layer
+    min-width 100%
     border-bottom 1px solid rgba(#fff, .1)
 
     &:focus,

--- a/packages/delir/views/Timeline/Layer.tsx
+++ b/packages/delir/views/Timeline/Layer.tsx
@@ -3,7 +3,7 @@ import { connectToStores, ContextProp, StoreGetter, withComponentContext } from 
 import * as classnames from 'classnames'
 import * as _ from 'lodash'
 import * as React from 'react'
-import { isWindows } from '../../utils/platform'
+import { SpreadType } from '../../utils/Spread'
 
 import * as EditorOps from '../../domain/Editor/operations'
 import * as ProjectOps from '../../domain/Project/operations'
@@ -21,7 +21,7 @@ import t from './Layer.i18n'
 import * as s from './Layer.styl'
 
 interface OwnProps {
-    layer: Readonly<Delir.Entity.Layer>
+    layer: SpreadType<Delir.Entity.Layer>
     layerIndex: number
     framerate: number
     pxPerSec: number
@@ -117,7 +117,7 @@ export default withComponentContext(
                                 return (
                                     <Clip
                                         key={clip.id!}
-                                        clip={clip}
+                                        clip={{ ...clip }}
                                         width={width}
                                         left={left}
                                         active={!!activeClip && clip.id === activeClip.id}

--- a/packages/delir/views/Timeline/Layer.tsx
+++ b/packages/delir/views/Timeline/Layer.tsx
@@ -27,6 +27,7 @@ interface OwnProps {
     pxPerSec: number
     scale: number
     scrollLeft: number
+    scrollWidth: number
 }
 
 type Props = OwnProps & ReturnType<typeof mapStoresToProps> & ContextProp
@@ -63,6 +64,7 @@ export default withComponentContext(
                     pxPerSec,
                     scale,
                     scrollLeft,
+                    scrollWidth,
                     postEffectPlugins,
                     userCodeException,
                 } = this.props
@@ -79,6 +81,7 @@ export default withComponentContext(
                         onMouseUp={this.handleMouseUp}
                         onFocus={this.handleFocus}
                         onBlur={this.handleBlur}
+                        style={{ width: scrollWidth }}
                         tabIndex={-1}
                     >
                         <ContextMenu>
@@ -116,7 +119,7 @@ export default withComponentContext(
                                         key={clip.id!}
                                         clip={clip}
                                         width={width}
-                                        left={left - scrollLeft}
+                                        left={left}
                                         active={!!activeClip && clip.id === activeClip.id}
                                         postEffectPlugins={postEffectPlugins}
                                         hasError={hasError}
@@ -189,12 +192,10 @@ export default withComponentContext(
             }
 
             private handleChangeClipPlace = (clipId: string, newPlacedPx: number) => {
-                const { scrollLeft } = this.props
-
                 const newPlacedFrame = TimePixelConversion.pixelToFrames({
                     pxPerSec: this.props.pxPerSec,
                     framerate: this.props.framerate,
-                    pixel: newPlacedPx + scrollLeft,
+                    pixel: newPlacedPx,
                     scale: this.props.scale,
                 })
 

--- a/packages/delir/views/Timeline/Layer.tsx
+++ b/packages/delir/views/Timeline/Layer.tsx
@@ -51,11 +51,6 @@ export default withComponentContext(
 
             private root = React.createRef<HTMLDivElement>()
 
-            public shouldComponentUpdate(nextProps: Props, nextState: State) {
-                const { props, state } = this
-                return !_.isEqual(props, nextProps) || !_.isEqual(state, nextState)
-            }
-
             public render() {
                 const {
                     layer,

--- a/packages/delir/views/Timeline/Timeline.tsx
+++ b/packages/delir/views/Timeline/Timeline.tsx
@@ -31,6 +31,7 @@ type Props = ReturnType<typeof mapStoresToProps> & ContextProp
 interface State {
     timelineScrollTop: number
     timelineScrollLeft: number
+    timelineScrollWidth: number
     cursorHeight: number
     scale: number
     selectedLayerId: string | null
@@ -60,6 +61,7 @@ export default withComponentContext(
             public state: State = {
                 timelineScrollTop: 0,
                 timelineScrollLeft: 0,
+                timelineScrollWidth: 0,
                 cursorHeight: 0,
                 scale: 1,
                 selectedLayerId: null,
@@ -80,11 +82,25 @@ export default withComponentContext(
             }
 
             public componentDidUpdate() {
+                const { activeComp } = this.props
+                const { scale } = this.state
                 this.labelContainer.current!.scrollTop = this.timelineContainer.current!.scrollTop = this.state.timelineScrollTop
+
+                if (activeComp) {
+                    const { durationFrames, framerate } = activeComp
+                    this.setState({
+                        timelineScrollWidth: TimePixelConversion.framesToPixel({
+                            pxPerSec: PX_PER_SEC,
+                            durationFrames: durationFrames + framerate * 1,
+                            framerate: framerate,
+                            scale,
+                        }),
+                    })
+                }
             }
 
             public render() {
-                const { scale, timelineScrollLeft } = this.state
+                const { scale, timelineScrollLeft, timelineScrollWidth } = this.state
                 const { previewPlayed, activeComp, activeClip, currentPointFrame } = this.props
                 const { framerate } = activeComp ? activeComp : { framerate: 30 }
                 const layers: Delir.Entity.Layer[] = activeComp ? Array.from(activeComp.layers) : []
@@ -191,6 +207,7 @@ export default withComponentContext(
                                                         scale={scale}
                                                         activeClip={activeClip}
                                                         scrollLeft={timelineScrollLeft}
+                                                        scrollWidth={timelineScrollWidth}
                                                     />
                                                 ))}
                                         </div>

--- a/packages/delir/views/Timeline/Timeline.tsx
+++ b/packages/delir/views/Timeline/Timeline.tsx
@@ -178,7 +178,7 @@ export default withComponentContext(
                                         </div>
                                     </Pane>
                                     {/* Layer Panel */}
-                                    <Pane className={s.timelineContainer} onWheel={this._scaleTimeline}>
+                                    <Pane className={s.timelineContainer} onWheel={this.handleScaleTimeline}>
                                         <Gradations
                                             activeComposition={activeComp}
                                             measures={measures}
@@ -194,6 +194,7 @@ export default withComponentContext(
                                         <div
                                             ref={this.timelineContainer}
                                             className={s.layerContainer}
+                                            onKeyDown={this.handleKeydownTimeline}
                                             onScroll={this.handleScrollTimeline}
                                         >
                                             {activeComp &&
@@ -286,7 +287,12 @@ export default withComponentContext(
                 })
             }
 
-            private _scaleTimeline = (e: React.WheelEvent<HTMLDivElement>) => {
+            private handleKeydownTimeline = (e: React.KeyboardEvent<HTMLDivElement>) => {
+                // Prevent scrolling by space key
+                if (e.keyCode === 32) e.preventDefault()
+            }
+
+            private handleScaleTimeline = (e: React.WheelEvent<HTMLDivElement>) => {
                 if (e.altKey) {
                     const newScale = this.state.scale + e.deltaY * 0.05
                     this.setState({ scale: Math.max(newScale, 0.1) })

--- a/packages/delir/views/Timeline/Timeline.tsx
+++ b/packages/delir/views/Timeline/Timeline.tsx
@@ -91,7 +91,7 @@ export default withComponentContext(
                     this.setState({
                         timelineScrollWidth: TimePixelConversion.framesToPixel({
                             pxPerSec: PX_PER_SEC,
-                            durationFrames: durationFrames + framerate * 1,
+                            durationFrames: durationFrames + framerate,
                             framerate: framerate,
                             scale,
                         }),
@@ -205,7 +205,6 @@ export default withComponentContext(
                                                         framerate={framerate}
                                                         pxPerSec={PX_PER_SEC}
                                                         scale={scale}
-                                                        activeClip={activeClip}
                                                         scrollLeft={timelineScrollLeft}
                                                         scrollWidth={timelineScrollWidth}
                                                     />

--- a/packages/delir/views/Timeline/style.styl
+++ b/packages/delir/views/Timeline/style.styl
@@ -62,6 +62,7 @@
     display flex
     flex-direction column
     flex 1
+    max-width 100%
     background-color $pane-background
 
 .layerContainer

--- a/yarn.lock
+++ b/yarn.lock
@@ -809,10 +809,10 @@
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
-"@ragg/fleur-react@0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@ragg/fleur-react/-/fleur-react-0.0.11.tgz#8bdfe25ab28822b20d7870a612568a29c6d3718a"
-  integrity sha512-m76hqybDf20qfcQwT3On10v75uxXQ/m78NTtt/DWPObi03MdYYuBA/9GoVyVY/hnmww6GTDFMl9cMtOWqXUxxQ==
+"@ragg/fleur-react@0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@ragg/fleur-react/-/fleur-react-0.0.12.tgz#e2cc124f9e61f45af59ebcf5879cbf956d3f6ce9"
+  integrity sha512-pW0S21llIgg0QOxsbvBVso4b5eTc+lyaCRbEcjHkTg5m/u0WQpGsfid+eLhFdNQAxPblGhPTQeI8rQFmrwUxKw==
 
 "@ragg/fleur@0.0.12":
   version "0.0.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,25 +911,20 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*":
-  version "10.12.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.0.tgz#ea6dcbddbc5b584c83f06c60e82736d8fbb0c235"
-  integrity sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==
-
-"@types/node@^10.12.18":
+"@types/node@*", "@types/node@^10.12.18":
   version "10.12.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
 
 "@types/node@^8.0.24":
-  version "8.10.36"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.36.tgz#eac05d576fbcd0b4ea3c912dc58c20475c08d9e4"
-  integrity sha512-SL6KhfM7PTqiFmbCW3eVNwVBZ+88Mrzbuvn9olPsfv43mbiWaFY+nRcz/TGGku0/lc2FepdMbImdMY1JrQ+zbw==
+  version "8.10.39"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.39.tgz#e7e87ad00364dd7bc485c940926345b8ec1a26ca"
+  integrity sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA==
 
 "@types/prop-types@*":
-  version "15.5.6"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.6.tgz#9c03d3fed70a8d517c191b7734da2879b50ca26c"
-  integrity sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ==
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
+  integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
 
 "@types/pug@^2.0.4":
   version "2.0.4"
@@ -971,15 +966,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "16.4.18"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.18.tgz#2e28a2e7f92d3fa7d6a65f2b73275c3e3138a13d"
-  integrity sha512-eFzJKEg6pdeaukVLVZ8Xb79CTl/ysX+ExmOfAAqcFlCCK5TgFDD9kWR0S18sglQ3EmM8U+80enjUqbfnUyqpdA==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
-"@types/react@16.7.20":
+"@types/react@*", "@types/react@16.7.20":
   version "16.7.20"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.20.tgz#13ae752c012710d0fa800985ca809814b51d3b58"
   integrity sha512-Qd5RWkwl6SL7R2XzLk/cicjVQm1Mhc6HqXY5Ei4pWd1Vi8Fkbd5O0sA398x8fRSTPAuHdDYD9nrWmJMYTJI0vQ==


### PR DESCRIPTION
Ticket: https://trello.com/c/BHnU4tI2/184-production-ux-improvement

Has breaking changes to public API?: No

#### Annotation to release
- タイムラインを拡大した時にガタッとスクロールが走る不具合を修正した！
- 実は映像処理より重かったUI処理を最適化してプレビュー再生がなめらかになった！

#### Breaking changes (In delir-core Public API or Expression/p5.js intergration API)
No 