### PR TITLE
Add schema prefix in Asset#path

### DIFF
--- a/packages/core-test-helper/index.ts
+++ b/packages/core-test-helper/index.ts
@@ -13,7 +13,7 @@ export const mockAsset = (props: Partial<LooseIdType<Entity.Asset>> = {}) =>
     safeAssign(
         new Entity.Asset({
             name: 'mock.png',
-            path: '/mocked/mock.png',
+            path: 'file:///mocked/mock.png',
             fileType: 'png',
         }),
         props as Partial<Entity.Asset>,

--- a/packages/core/spec/fixture/project/2019052601.delir.json
+++ b/packages/core/spec/fixture/project/2019052601.delir.json
@@ -1,0 +1,300 @@
+{
+  "__type": "entity:Project",
+  "__value": {
+    "formatVersion": "2017091401",
+    "assets": [
+      {
+        "__type": "entity:Asset",
+        "__value": {
+          "id": "78262d20-af63-4520-abfd-34e85e855618",
+          "name": "BigBuckBunny",
+          "fileType": "mp4",
+          "path": "file:///Users/ragg/workspace/delir/packages/delir/utils/Dev/ExampleProject1/big_buck_bunny.mp4"
+        }
+      },
+      {
+        "__type": "entity:Asset",
+        "__value": {
+          "id": "3748e817-9c43-43d4-be63-b8ddcd25a2fc",
+          "name": "Audio",
+          "fileType": "mp3",
+          "path": "file:///Users/ragg/workspace/delir/packages/delir/utils/Dev/ExampleProject1/audio.mp3"
+        }
+      },
+      {
+        "__type": "entity:Asset",
+        "__value": {
+          "id": "0bbb7142-e2c2-4a8a-9a98-4adc833bcff1",
+          "name": "Image",
+          "fileType": "png",
+          "path": "file:///Users/ragg/workspace/delir/packages/delir/utils/Dev/ExampleProject1/image.png"
+        }
+      }
+    ],
+    "compositions": [
+      {
+        "__type": "entity:Composition",
+        "__value": {
+          "layers": [
+            {
+              "__type": "entity:Layer",
+              "__value": {
+                "clips": [
+                  {
+                    "__type": "entity:Clip",
+                    "__value": {
+                      "keyframes": {},
+                      "expressions": {},
+                      "effects": [
+                        {
+                          "__type": "entity:Effect",
+                          "__value": {
+                            "keyframes": {},
+                            "expressions": {},
+                            "referenceName": null,
+                            "id": "35f0f3b1-cbb1-42fc-84e1-d12c8f64327b",
+                            "processor": "@ragg/delir-posteffect-chromakey"
+                          }
+                        }
+                      ],
+                      "id": "a9051c4f-d29c-41e9-aa63-5245eaf2b0d0",
+                      "placedFrame": 0,
+                      "durationFrames": 300,
+                      "renderer": "adjustment"
+                    }
+                  }
+                ],
+                "id": "a0ddb7e0-2f68-4ccc-b1a5-1f0a170ea31b",
+                "name": "Audio"
+              }
+            },
+            {
+              "__type": "entity:Layer",
+              "__value": {
+                "clips": [
+                  {
+                    "__type": "entity:Clip",
+                    "__value": {
+                      "keyframes": {
+                        "text": [
+                          {
+                            "__type": "entity:Keyframe",
+                            "__value": {
+                              "easeInParam": [
+                                1,
+                                1
+                              ],
+                              "easeOutParam": [
+                                0,
+                                0
+                              ],
+                              "id": "8930d590-e735-431b-acf0-1629b36c6b3f",
+                              "frameOnClip": 0,
+                              "value": "test"
+                            }
+                          }
+                        ],
+                        "source": [
+                          {
+                            "__type": "entity:Keyframe",
+                            "__value": {
+                              "easeInParam": [
+                                1,
+                                1
+                              ],
+                              "easeOutParam": [
+                                0,
+                                0
+                              ],
+                              "id": "ceaefa04-be43-485e-9ccd-a9f88ec7d0a8",
+                              "frameOnClip": 0,
+                              "value": {
+                                "assetId": "78262d20-af63-4520-abfd-34e85e855618"
+                              }
+                            }
+                          }
+                        ],
+                        "loop": [
+                          {
+                            "__type": "entity:Keyframe",
+                            "__value": {
+                              "easeInParam": [
+                                1,
+                                1
+                              ],
+                              "easeOutParam": [
+                                0,
+                                0
+                              ],
+                              "id": "3d6efba8-5c1b-4d2b-82df-72afd401fe11",
+                              "frameOnClip": 0,
+                              "value": true
+                            }
+                          }
+                        ],
+                        "color": [
+                          {
+                            "__type": "entity:Keyframe",
+                            "__value": {
+                              "easeInParam": [
+                                1,
+                                1
+                              ],
+                              "easeOutParam": [
+                                0,
+                                0
+                              ],
+                              "id": "c541dd9f-9568-446b-80fe-c15f7824168e",
+                              "frameOnClip": 0,
+                              "value": {
+                                "__type": "value:ColorRGBA",
+                                "__value": {
+                                  "_red": 0,
+                                  "_green": 0,
+                                  "_blue": 0,
+                                  "_alpha": 1
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "expressions": {
+                        "text": {
+                          "__type": "value:Expression",
+                          "__value": {
+                            "language": "typescript",
+                            "code": "`time:${time}\\nframe:${frame}`"
+                          }
+                        }
+                      },
+                      "effects": [],
+                      "id": "18e7e762-6573-4870-9042-3413db72fc92",
+                      "placedFrame": 0,
+                      "durationFrames": 300,
+                      "renderer": "text"
+                    }
+                  }
+                ],
+                "id": "63d0293a-9a7e-451b-9a20-8b9f6a587c0a",
+                "name": "🔥 FIRE 🔥"
+              }
+            },
+            {
+              "__type": "entity:Layer",
+              "__value": {
+                "clips": [],
+                "id": "8029b087-d6a5-4c26-873f-020c5133891a",
+                "name": "NYAN = ^ . ^ = CAT"
+              }
+            },
+            {
+              "__type": "entity:Layer",
+              "__value": {
+                "clips": [
+                  {
+                    "__type": "entity:Clip",
+                    "__value": {
+                      "keyframes": {
+                        "sketch": [
+                          {
+                            "__type": "entity:Keyframe",
+                            "__value": {
+                              "easeInParam": [
+                                1,
+                                1
+                              ],
+                              "easeOutParam": [
+                                0,
+                                0
+                              ],
+                              "id": "b2b63621-1ed3-4baa-8122-6e91a9028c35",
+                              "frameOnClip": 0,
+                              "value": {
+                                "__type": "value:Expression",
+                                "__value": {
+                                  "language": "javascript",
+                                  "code": "\n// Link: https://p5js.org/examples/simulate-snowflakes.html\nlet snowflakes = []; // array to hold snowflake objects\nlet img\n\nfunction setup() {\n    // createCanvas(400, 600);\n    // fill(240);\n    noStroke();\n    img = loadImage('delir:0bbb7142-e2c2-4a8a-9a98-4adc833bcff1')\n}\n\nfunction draw() {\n    // background('brown');\n    clear();\n    image(img, 0, 0, img.width / 6, img.height / 6);\n    let t = frameCount / 60; // update time\n\n    // create a random number of snowflakes each frame\n    for (var i = 0; i < random(5); i++) {\n        snowflakes.push(new snowflake()); // append snowflake object\n    }\n\n    // loop through snowflakes with a for..of loop\n    for (let flake of snowflakes) {\n        flake.update(t); // update snowflake position\n        flake.display(); // draw snowflake\n    }\n}\n\n// snowflake class\nfunction snowflake() {\n    // initialize coordinates\n    this.posX = 0;\n    this.posY = random(-50, 0);\n    this.initialangle = random(0, 2 * PI);\n    this.size = random(2, 5);\n\n    // radius of snowflake spiral\n    // chosen so the snowflakes are uniformly spread out in area\n    this.radius = sqrt(random(pow(width / 2, 2)));\n\n    this.update = function(time) {\n        // x position follows a circle\n        let w = 0.6; // angular speed\n        let angle = w * time + this.initialangle;\n        this.posX = width / 2 + this.radius * sin(angle);\n\n        // different size snowflakes fall at slightly different y speeds\n        this.posY += pow(this.size, 0.5);\n\n        // delete snowflake if past end of screen\n        if (this.posY > height) {\n            let index = snowflakes.indexOf(this);\n            snowflakes.splice(index, 1);\n        }\n    };\n\n    this.display = function() {\n        ellipse(this.posX, this.posY, this.size);\n    };\n}\n"
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "expressions": {},
+                      "effects": [],
+                      "id": "53a5c6e4-9bb8-4c4f-a6e7-02c790cae95c",
+                      "placedFrame": 0,
+                      "durationFrames": 300,
+                      "renderer": "p5js"
+                    }
+                  }
+                ],
+                "id": "b9ecc990-a5c5-4cfc-891b-7953adac2324",
+                "name": "VERY CUTE 🐰-CHAN"
+              }
+            },
+            {
+              "__type": "entity:Layer",
+              "__value": {
+                "clips": [
+                  {
+                    "__type": "entity:Clip",
+                    "__value": {
+                      "keyframes": {
+                        "source": [
+                          {
+                            "__type": "entity:Keyframe",
+                            "__value": {
+                              "easeInParam": [
+                                1,
+                                1
+                              ],
+                              "easeOutParam": [
+                                0,
+                                0
+                              ],
+                              "id": "e4bfa068-bb54-4c2e-9fda-70355af9149b",
+                              "frameOnClip": 0,
+                              "value": {
+                                "assetId": "78262d20-af63-4520-abfd-34e85e855618"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "expressions": {},
+                      "effects": [],
+                      "id": "00c7c322-394d-4eb3-be49-5c31ce2a81c6",
+                      "placedFrame": 0,
+                      "durationFrames": 300,
+                      "renderer": "video"
+                    }
+                  }
+                ],
+                "id": "e7ec7d37-0015-40e2-943d-24b8225c085a",
+                "name": "GENERATIVE"
+              }
+            }
+          ],
+          "id": "784fda14-4075-4f85-9aab-d9413d3b2c1a",
+          "name": "Master Composition",
+          "width": 640,
+          "height": 360,
+          "framerate": 30,
+          "durationFrames": 300,
+          "audioChannels": 2,
+          "samplingRate": 48000,
+          "backgroundColor": {
+            "__type": "value:ColorRGB",
+            "__value": {
+              "_red": 0,
+              "_green": 188,
+              "_blue": 255
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/packages/core/src/Engine/Renderer/Audio/Audio.ts
+++ b/packages/core/src/Engine/Renderer/Audio/Audio.ts
@@ -68,8 +68,8 @@ export default class AudioRenderer implements IRenderer<AudioRendererParam> {
 
         // `AudioContext` cause depletion, use OfflineAudioContext
         const audioCtx = new OfflineAudioContext(1, context.audioChannels, context.samplingRate)
-        const content = fs.readFileSync(params.source.path)
-        const audioBuffer = await audioCtx.decodeAudioData(content.buffer as ArrayBuffer)
+        const content = await (await fetch(params.source.path)).arrayBuffer()
+        const audioBuffer = await audioCtx.decodeAudioData(content)
         const buffers = _.times(audioBuffer.numberOfChannels, ch => audioBuffer.getChannelData(ch))
 
         await resampling(audioBuffer.sampleRate, context.samplingRate, buffers)

--- a/packages/core/src/Engine/Renderer/Audio/Audio.ts
+++ b/packages/core/src/Engine/Renderer/Audio/Audio.ts
@@ -48,7 +48,7 @@ export default class AudioRenderer implements IRenderer<AudioRendererParam> {
             })
     }
 
-    private _audio: {
+    private audio: {
         sourcePath: string
         numberOfChannels: number
         buffers: Float32Array[]
@@ -58,11 +58,11 @@ export default class AudioRenderer implements IRenderer<AudioRendererParam> {
         const params = context.parameters
 
         if (!params.source) {
-            this._audio = null
+            this.audio = null
             return
         }
 
-        if (this._audio && this._audio.sourcePath === params.source.path) {
+        if (this.audio && this.audio.sourcePath === params.source.path) {
             return
         }
 
@@ -74,7 +74,7 @@ export default class AudioRenderer implements IRenderer<AudioRendererParam> {
 
         await resampling(audioBuffer.sampleRate, context.samplingRate, buffers)
 
-        this._audio = {
+        this.audio = {
             sourcePath: params.source.path,
             numberOfChannels: audioBuffer.numberOfChannels,
             buffers,
@@ -87,11 +87,11 @@ export default class AudioRenderer implements IRenderer<AudioRendererParam> {
 
     public async renderAudio(context: ClipRenderContext<AudioRendererParam>) {
         if (!context.isAudioBufferingNeeded) return
-        if (!this._audio) return
+        if (!this.audio) return
 
         const volume = _.clamp(context.parameters.volume / 100, 0, 1)
 
-        const source = this._audio
+        const source = this.audio
         const destBuffers = context.destAudioBuffer
 
         // Placement offset

--- a/packages/core/src/Engine/Renderer/Image/Image.ts
+++ b/packages/core/src/Engine/Renderer/Image/Image.ts
@@ -62,37 +62,37 @@ export default class ImageLayer implements IRenderer<ImageRendererParams> {
             })
     }
 
-    private _image: HTMLImageElement | null = null
+    private image: HTMLImageElement | null = null
 
     public async beforeRender(context: ClipPreRenderContext<ImageRendererParams>) {
         const parameters = context.parameters
 
         if (!parameters.source) {
-            this._image = null
+            this.image = null
             return
         }
 
-        this._image = new Image()
-        this._image.src = parameters.source.path
+        this.image = new Image()
+        this.image.src = parameters.source.path
 
         await new Promise((resolve, reject) => {
-            this._image!.addEventListener('load', () => resolve(), {
+            this.image!.addEventListener('load', () => resolve(), {
                 once: true,
             } as any)
-            this._image!.addEventListener(
+            this.image!.addEventListener(
                 'error',
-                () => reject(new Error(`ImageLayer: Image not found (URL: ${this._image!.src})`)),
+                () => reject(new Error(`ImageLayer: Image not found (URL: ${this.image!.src})`)),
                 { once: true } as any,
             )
         })
     }
 
     public async render(context: ClipRenderContext<ImageRendererParams>) {
-        if (!this._image) return
+        if (!this.image) return
 
         const param = context.parameters
         const ctx = context.destCanvas.getContext('2d')!
-        const img = this._image
+        const img = this.image
         const rad = (param.rotate * Math.PI) / 180
 
         ctx.globalAlpha = _.clamp(param.opacity, 0, 100) / 100

--- a/packages/core/src/Engine/Renderer/Image/Image.ts
+++ b/packages/core/src/Engine/Renderer/Image/Image.ts
@@ -73,7 +73,7 @@ export default class ImageLayer implements IRenderer<ImageRendererParams> {
         }
 
         this._image = new Image()
-        this._image.src = `file://${parameters.source.path}`
+        this._image.src = parameters.source.path
 
         await new Promise((resolve, reject) => {
             this._image!.addEventListener('load', () => resolve(), {

--- a/packages/core/src/Engine/Renderer/P5js/P5Hooks.ts
+++ b/packages/core/src/Engine/Renderer/P5js/P5Hooks.ts
@@ -31,7 +31,7 @@ export default class P5Hooks {
         const match = /^delir:(.+)/.exec(path)
 
         if (match) {
-            path = 'file://' + this.resolver.resolveAsset(match[1])!.path
+            path = this.resolver.resolveAsset(match[1])!.path
         }
 
         return P5.prototype.loadImage.call(this.p5, path, successCallback, failureCallback)

--- a/packages/core/src/Engine/Renderer/Text/Text.ts
+++ b/packages/core/src/Engine/Renderer/Text/Text.ts
@@ -98,10 +98,10 @@ export default class TextLayer implements IRenderer<TextRendererParam> {
         return {}
     }
 
-    private _bufferCanvas: HTMLCanvasElement
+    private bufferCanvas: HTMLCanvasElement
 
     public async beforeRender(context: ClipPreRenderContext<TextRendererParam>) {
-        this._bufferCanvas = document.createElement('canvas')
+        this.bufferCanvas = document.createElement('canvas')
     }
 
     public async render(context: ClipRenderContext<TextRendererParam>) {

--- a/packages/core/src/Engine/Renderer/Video/Video.ts
+++ b/packages/core/src/Engine/Renderer/Video/Video.ts
@@ -80,7 +80,7 @@ export default class VideoLayer implements IRenderer<VideoRendererParam> {
         }
 
         const video = (this._video = document.createElement('video'))
-        this._video.src = `file://${parameters.source.path}`
+        this._video.src = parameters.source.path
         this._video.loop = parameters.loop
         this._video.load()
         this._video.currentTime = -1

--- a/packages/core/src/Engine/Renderer/Video/Video.ts
+++ b/packages/core/src/Engine/Renderer/Video/Video.ts
@@ -69,21 +69,21 @@ export default class VideoLayer implements IRenderer<VideoRendererParam> {
             })
     }
 
-    private _video: HTMLVideoElement | null
+    private video: HTMLVideoElement | null
 
     public async beforeRender(context: ClipPreRenderContext<VideoRendererParam>) {
         const parameters = context.parameters as any
 
         if (context.parameters.source == null) {
-            this._video = null
+            this.video = null
             return
         }
 
-        const video = (this._video = document.createElement('video'))
-        this._video.src = parameters.source.path
-        this._video.loop = parameters.loop
-        this._video.load()
-        this._video.currentTime = -1
+        const video = (this.video = document.createElement('video'))
+        this.video.src = parameters.source.path
+        this.video.loop = parameters.loop
+        this.video.load()
+        this.video.currentTime = -1
 
         await new Promise((resolve, reject) => {
             const onLoaded = () => {
@@ -114,7 +114,7 @@ export default class VideoLayer implements IRenderer<VideoRendererParam> {
 
         const param = context.parameters
         const ctx = context.destCanvas.getContext('2d')!
-        const video = this._video
+        const video = this.video
 
         if (!video) return
 

--- a/packages/core/src/Entity/Asset.ts
+++ b/packages/core/src/Entity/Asset.ts
@@ -17,6 +17,7 @@ class Asset implements AssetProps {
     /** Asset file extension (without `.` prefix) */
     public fileType: string
     public name: string
+    /** Full file path with schema (likes 'file:///path/to/asset.mp4) */
     public path: string
 
     constructor(props: AssetProps) {

--- a/packages/core/src/Entity/Project.ts
+++ b/packages/core/src/Entity/Project.ts
@@ -9,7 +9,7 @@ export interface ProjectProps {
 }
 
 export class Project implements ProjectProps {
-    public readonly formatVersion: string = '2017091401'
+    public readonly formatVersion: string = '2019052601'
     public assets: ReadonlyArray<Asset> = []
     public compositions: ReadonlyArray<Composition> = []
 

--- a/packages/core/src/Migration/ProjectMigrator.spec.ts
+++ b/packages/core/src/Migration/ProjectMigrator.spec.ts
@@ -1,0 +1,11 @@
+import * as p2017091401 from '../../spec/fixture/project/2017091401.delir.json'
+import { deserializeProject } from '../Exporter'
+import ProjectMigrator from './ProjectMigrator'
+
+describe('ProjectMigrator', () => {
+    it('Migrate to 2019052601 from 2017091401', () => {
+        const beforeMigration = deserializeProject(p2017091401)
+        const afterMigration = ProjectMigrator.migrate(beforeMigration)
+        expect(afterMigration.assets).toMatchSnapshot()
+    })
+})

--- a/packages/core/src/Migration/ProjectMigrator.ts
+++ b/packages/core/src/Migration/ProjectMigrator.ts
@@ -1,12 +1,24 @@
 import * as _ from 'lodash'
+import { Project } from '../Entity/Project'
+import { walkAssets } from './MigrationHelper'
 
 export default {
-    isMigratable: (project: any) => {
+    isMigratable: (project: Project) => {
+        if (project.formatVersion === '2017091401') {
+            return true
+        }
+
         return false
     },
 
     /** Migrate project to latest schema at migratable version */
-    migrate: (project: any) => {
+    migrate: (project: Project) => {
+        if (project.formatVersion === '2017091401') {
+            walkAssets(project, asset => {
+                asset.path = `file://${asset.path}`
+            })
+        }
+
         return project
     },
 }

--- a/packages/core/src/Migration/__snapshots__/ProjectMigrator.spec.ts.snap
+++ b/packages/core/src/Migration/__snapshots__/ProjectMigrator.spec.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProjectMigrator Migrate to 2019052601 from 2017091401 1`] = `
+Array [
+  Asset {
+    "fileType": "mp4",
+    "id": "78262d20-af63-4520-abfd-34e85e855618",
+    "name": "BigBuckBunny",
+    "path": "file:///Users/ragg/workspace/delir/packages/delir/utils/Dev/ExampleProject1/big_buck_bunny.mp4",
+  },
+  Asset {
+    "fileType": "mp3",
+    "id": "3748e817-9c43-43d4-be63-b8ddcd25a2fc",
+    "name": "Audio",
+    "path": "file:///Users/ragg/workspace/delir/packages/delir/utils/Dev/ExampleProject1/audio.mp3",
+  },
+  Asset {
+    "fileType": "png",
+    "id": "0bbb7142-e2c2-4a8a-9a98-4adc833bcff1",
+    "name": "Image",
+    "path": "file:///Users/ragg/workspace/delir/packages/delir/utils/Dev/ExampleProject1/image.png",
+  },
+]
+`;

--- a/packages/core/src/__snapshots__/Exporter.spec.ts.snap
+++ b/packages/core/src/__snapshots__/Exporter.spec.ts.snap
@@ -11,7 +11,7 @@ Object {
           "fileType": "png",
           "id": "uuid-asset",
           "name": "mock.png",
-          "path": "/mocked/mock.png",
+          "path": "file:///mocked/mock.png",
         },
       },
     ],
@@ -163,7 +163,7 @@ Object {
         },
       },
     ],
-    "formatVersion": "2017091401",
+    "formatVersion": "2019052601",
   },
 }
 `;

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -1,6 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
+        "resolveJsonModule": true,
         "module": "commonjs"
     }
 }

--- a/packages/delir/__spec__/fixtures/Project.ts
+++ b/packages/delir/__spec__/fixtures/Project.ts
@@ -11,25 +11,25 @@ const project = new Delir.Entity.Project({})
 const movieAsset = new Delir.Entity.Asset({
     name: 'Movie',
     fileType: 'mp4',
-    path: join(process.cwd(), 'video.mp4'),
+    path: 'file://' + join(process.cwd(), 'video.mp4'),
 })
 
 const audioAsset = new Delir.Entity.Asset({
     name: 'Audio',
     fileType: 'mp3',
-    path: join(process.cwd(), 'audio.mp3'),
+    path: 'file://' + join(process.cwd(), 'audio.mp3'),
 })
 
 const audioAsset2 = new Delir.Entity.Asset({
     name: 'Audio',
     fileType: 'mp3',
-    path: join(process.cwd(), 'audio.mp3'),
+    path: 'file://' + join(process.cwd(), 'audio.mp3'),
 })
 
 const imageAsset = new Delir.Entity.Asset({
     name: 'Image',
     fileType: 'jpg',
-    path: join(process.cwd(), 'image.jpg'),
+    path: 'file://' + join(process.cwd(), 'image.jpg'),
 })
 
 // Maser Composition

--- a/packages/delir/domain/Project/__snapshots__/models.spec.ts.snap
+++ b/packages/delir/domain/Project/__snapshots__/models.spec.ts.snap
@@ -90,6 +90,6 @@ Project {
       "width": 100,
     },
   ],
-  "formatVersion": "2017091401",
+  "formatVersion": "2019052601",
 }
 `;

--- a/packages/delir/domain/Project/operations.ts
+++ b/packages/delir/domain/Project/operations.ts
@@ -420,6 +420,7 @@ export const addAsset = operation(
         },
     ) => {
         const asset = new Delir.Entity.Asset({ name, fileType, path })
+
         await context.executeOperation(HistoryOps.pushHistory, {
             command: new AddAssetCommand(asset),
         })

--- a/packages/delir/utils/Dev/ExampleProject1/index.ts
+++ b/packages/delir/utils/Dev/ExampleProject1/index.ts
@@ -11,19 +11,19 @@ const project = new Delir.Entity.Project({})
 const videoAsset = new Delir.Entity.Asset({
     name: 'BigBuckBunny',
     fileType: 'mp4',
-    path: join(dirname, 'big_buck_bunny.mp4'),
+    path: 'file://' + join(dirname, 'big_buck_bunny.mp4'),
 })
 
 const audioAsset = new Delir.Entity.Asset({
     name: 'Audio',
     fileType: 'mp3',
-    path: join(dirname, 'Dawn.mp3'),
+    path: 'file://' + join(dirname, 'Dawn.mp3'),
 })
 
 const imageAsset = new Delir.Entity.Asset({
     name: 'Image',
     fileType: 'png',
-    path: join(dirname, 'image.png'),
+    path: 'file://' + join(dirname, 'image.png'),
 })
 ;[videoAsset, audioAsset, imageAsset].forEach(asset => project.addAsset(asset))
 

--- a/packages/delir/views/AssetsView/AssetsView.tsx
+++ b/packages/delir/views/AssetsView/AssetsView.tsx
@@ -291,7 +291,7 @@ export default withComponentContext(
                     this.props.executeOperation(ProjectOps.addAsset, {
                         name: file.name,
                         fileType: path.extname(file.name).slice(1),
-                        path: file.path,
+                        path: 'file://' + file.path,
                     })
                 })
             }


### PR DESCRIPTION
Ticket: None

Has breaking changes to public API?: Yes

- エンジン単体利用向けにURIにスキーマを付加するようにした
  - 今までは `file://` 前提だったが、これで`https://`とか`blob:`越しにアセットを読み込めるようになるはず

#### Annotation to release
- 内部更新: `Asset#path` がスキーマ付きURIへ変更された(自動でマイグレーションされます)

#### Breaking changes (In delir-core Public API or Expression/p5.js intergration API)
- In `@delirvfx/core`, `Asset#path` now added URI schema. (Auto migrated)
