### PR TITLE
Improve browser support

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
+### 0.7.4
+- #226 Fix plugin's package.json typing
+- #226 Replace `joi` dependency to `joi-browser`
+
 ### 0.7.3
-- [Experimental] `@delirvfx/core` now can be used as standalone package.
+- [Experimental] `@delirvfx/core` now can be used as standalone package
 - Export core version from `version`
 
 ### 0.7.1, 0.7.2

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "bezier-easing": "2.1.0",
     "font-manager": "0.3.0",
-    "joi": "14.3.1",
+    "joi-browser": "^13.4.0",
     "lodash": "4.17.11",
     "p5": "0.8.0",
     "semver": "6.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delirvfx/core",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "JavaScript VFX Engine",
   "main": "lib/index.js",
   "types": "typings/index.d.ts",

--- a/packages/core/src/Engine/Task/EffectRenderTask.spec.ts
+++ b/packages/core/src/Engine/Task/EffectRenderTask.spec.ts
@@ -42,7 +42,7 @@ describe('EffectRenderTask', () => {
                             type: 'post-effect',
                         },
                         engines: {
-                            'delir-core': '*',
+                            '@delirvfx/core': '*',
                         },
                     },
                     type: 'post-effect',

--- a/packages/core/src/PluginSupport/PluginRegistry.spec.ts
+++ b/packages/core/src/PluginSupport/PluginRegistry.spec.ts
@@ -9,7 +9,7 @@ describe('PluginRegistry', () => {
                 author: 'ragg <ragg.devpr@gmail.com>',
                 main: 'index.js',
                 engines: {
-                    'delir-core': '0.0.0',
+                    '@delirvfx/core': '0.0.0',
                     node: '10.0.0',
                 },
                 delir: {
@@ -29,8 +29,8 @@ describe('PluginRegistry', () => {
                 version: '0.0.0',
                 author: 'ragg <ragg.devpr@gmail.com>',
                 engines: {
-                    'delir-core': '0.0.0',
-                    // 'delir-core': '0.0.0.1',
+                    '@delirvfx/core': '0.0.0',
+                    // '@delirvfx/core': '0.0.0.1',
                 },
                 delir: {
                     name: 'Effect',

--- a/packages/core/src/PluginSupport/plugin-registry.ts
+++ b/packages/core/src/PluginSupport/plugin-registry.ts
@@ -68,7 +68,7 @@ export default class PluginRegistry {
 
             const requiredEngineVersion =
                 entry.packageJson.engines['@delirvfx/core'] || entry.packageJson.engines['delir-core']
-            if (!semver.satisfies(engineVersion, requiredEngineVersion)) {
+            if (!semver.satisfies(engineVersion, requiredEngineVersion!)) {
                 throw new PluginLoadFailException(
                     `Plugin \`${entry.id}\` not compatible to current @delirvfx/core version`,
                 )

--- a/packages/core/src/PluginSupport/plugin-registry.ts
+++ b/packages/core/src/PluginSupport/plugin-registry.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi'
+import * as Joi from 'joi-browser'
 import * as _ from 'lodash'
 import * as semver from 'semver'
 

--- a/packages/core/src/PluginSupport/plugin-registry.ts
+++ b/packages/core/src/PluginSupport/plugin-registry.ts
@@ -24,7 +24,8 @@ const effectPluginPackageJSONSchema = Joi.object()
         author: [Joi.string(), Joi.array().items(Joi.string())],
         main: Joi.string().optional(),
         engines: Joi.object().keys({
-            'delir-core': Joi.string()
+            'delir-core': Joi.string().regex(SEMVER_REGEXP),
+            '@delirvfx/core': Joi.string()
                 .regex(SEMVER_REGEXP)
                 .required(),
         }),
@@ -41,7 +42,8 @@ export default class PluginRegistry {
     public static validateEffectPluginPackageJSON(packageJSON: any): packageJSON is DelirPluginPackageJson {
         return (
             Joi.validate(packageJSON, effectPluginPackageJSONSchema).error == null &&
-            semver.valid(packageJSON.engines['delir-core']) != null &&
+            (semver.valid(packageJSON.engines['delir-core']) != null ||
+                semver.valid(packageJSON.engines['@delirvfx/core']) != null) &&
             semver.valid(packageJSON.version) != null
         )
     }

--- a/packages/core/src/PluginSupport/types.ts
+++ b/packages/core/src/PluginSupport/types.ts
@@ -14,7 +14,7 @@ export interface DelirPluginPackageJson {
     author: string | string[]
     main?: string
     engines: {
-        'delir-core': string
+        'delir-core'?: string
         '@delirvfx/core': string
     }
     delir: PackageJSONDelirSection

--- a/packages/core/src/declarations.d.ts
+++ b/packages/core/src/declarations.d.ts
@@ -8,25 +8,9 @@ declare module 'electron-canvas-to-buffer' {
     export default _
 }
 
-declare module 'audiobuffer-to-wav' {
-    interface AudioBufferLike {
-        sampleRate: number
-        numberOfChannels: number
-        getChannelData: (channel: number) => Float32Array
-    }
-
-    const _: (buffer: AudioBufferLike, opts: { float32: boolean }) => ArrayBuffer
-    export = _
-}
-
-declare module 'arraybuffer-to-buffer' {
-    const _: (ab: ArrayBuffer) => Buffer
-    export = _
-}
-
-declare module 'keymirror' {
-    const _: (obj: {}) => { [key: string]: string }
-    export default _
+declare module 'joi-browser' {
+    import * as joi from 'joi'
+    export = joi
 }
 
 declare module 'node-timecodes' {

--- a/packages/deream/declarations.d.ts
+++ b/packages/deream/declarations.d.ts
@@ -1,0 +1,15 @@
+declare module 'audiobuffer-to-wav' {
+    interface AudioBufferLike {
+        sampleRate: number
+        numberOfChannels: number
+        getChannelData: (channel: number) => Float32Array
+    }
+
+    const _: (buffer: AudioBufferLike, opts: { float32: boolean }) => ArrayBuffer
+    export = _
+}
+
+declare module 'arraybuffer-to-buffer' {
+    const _: (ab: ArrayBuffer) => Buffer
+    export = _
+}

--- a/packages/web-example/package.json
+++ b/packages/web-example/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@delirvfx/core": "*",
     "lodash-es": "4.17.11",
-    "node-libs-browser": "2.2.0"
+    "random-emoji": "1.0.2"
   },
   "devDependencies": {
     "@types/lodash-es": "4.17.3",

--- a/packages/web-example/src/ExamplePlugin.ts
+++ b/packages/web-example/src/ExamplePlugin.ts
@@ -1,0 +1,27 @@
+import { EffectRenderContext, PostEffectBase } from '@delirvfx/core'
+import randomEmoji from 'random-emoji'
+
+export class ExamplePlugin extends PostEffectBase {
+    private emojis: string[]
+
+    public async initialize() {
+        this.emojis = this.generateEmoji(10)
+    }
+
+    public async render(context: EffectRenderContext<{}>) {
+        if (context.frame % 3 === 0) {
+            this.emojis.push(this.generateEmoji(1))
+            this.emojis.shift()
+        }
+
+        const ctx = context.destCanvas.getContext('2d')
+        ctx.fillStyle = '#000'
+        ctx.font = '32px "sans-serif"'
+        ctx.textBaseline = 'top'
+        ctx.fillText(`This is post effect ${this.emojis.join('')}`, 10, 10)
+    }
+
+    private generateEmoji(count: number) {
+        return randomEmoji.random({ count }).map((e: any) => e.character)
+    }
+}

--- a/packages/web-example/webpack.config.ts
+++ b/packages/web-example/webpack.config.ts
@@ -10,9 +10,6 @@ export default (): webpack.Configuration => ({
     },
     resolve: {
         extensions: ['.js', '.ts'],
-        alias: {
-            net: 'node-libs-browser/mock/net.js',
-        },
     },
     module: {
         rules: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6837,6 +6837,11 @@ jimp@^0.2.27:
     tinycolor2 "^1.1.2"
     url-regex "^3.0.0"
 
+joi-browser@^13.4.0:
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/joi-browser/-/joi-browser-13.4.0.tgz#b72ba61b610e3f58e51b563a14e0f5225cfb6896"
+  integrity sha512-TfzJd2JaJ/lg/gU+q5j9rLAjnfUNF9DUmXTP9w+GfmG79LjFOXFeM7hIFuXCBcZCivUDFwd9l1btTV9rhHumtQ==
+
 joi@14.3.1:
   version "14.3.1"
   resolved "https://registry.yarnpkg.com/joi/-/joi-14.3.1.tgz#164a262ec0b855466e0c35eea2a885ae8b6c703c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2350,13 +2350,6 @@ browserify-zlib@^0.1.4:
   dependencies:
     pako "~0.2.0"
 
-browserify-zlib@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
-  integrity sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
-  dependencies:
-    pako "~1.0.5"
-
 browserslist@^4.5.2, browserslist@^4.5.4:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.5.5.tgz#fe1a352330d2490d5735574c149a85bc18ef9b82"
@@ -4059,6 +4052,11 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+emoji-named-characters@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/emoji-named-characters/-/emoji-named-characters-1.0.2.tgz#cdeb36d0e66002c4b9d7bf1dfbc3a199fb7d409b"
+  integrity sha1-zes20OZgAsS5178d+8Ohmft9QJs=
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -4243,11 +4241,6 @@ events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
-
-events@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
-  integrity sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==
 
 evp_bytestokey@^1.0.0:
   version "1.0.0"
@@ -5672,11 +5665,6 @@ https-browserify@0.0.1:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
   integrity sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=
 
-https-browserify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
-  integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
-
 humanize-plus@^1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/humanize-plus/-/humanize-plus-1.8.2.tgz#a65b34459ad6367adbb3707a82a3c9f916167030"
@@ -5835,7 +5823,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
@@ -7439,6 +7427,11 @@ lodash.pick@^4.2.1:
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
 
+lodash.shuffle@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz#145b5053cf875f6f5c2a33f48b6e9948c6ec7b4b"
+  integrity sha1-FFtQU8+HX29cKjP0i26ZSMbse0s=
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -8059,35 +8052,6 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
-node-libs-browser@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.0.tgz#c72f60d9d46de08a940dedbb25f3ffa2f9bbaa77"
-  integrity sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==
-  dependencies:
-    assert "^1.1.1"
-    browserify-zlib "^0.2.0"
-    buffer "^4.3.0"
-    console-browserify "^1.1.0"
-    constants-browserify "^1.0.0"
-    crypto-browserify "^3.11.0"
-    domain-browser "^1.1.1"
-    events "^3.0.0"
-    https-browserify "^1.0.0"
-    os-browserify "^0.3.0"
-    path-browserify "0.0.0"
-    process "^0.11.10"
-    punycode "^1.2.4"
-    querystring-es3 "^0.2.0"
-    readable-stream "^2.3.3"
-    stream-browserify "^2.0.1"
-    stream-http "^2.7.2"
-    string_decoder "^1.0.0"
-    timers-browserify "^2.0.4"
-    tty-browserify "0.0.0"
-    url "^0.11.0"
-    util "^0.11.0"
-    vm-browserify "0.0.4"
-
 node-libs-browser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.0.0.tgz#a3a59ec97024985b46e958379646f96c4b616646"
@@ -8530,11 +8494,6 @@ os-browserify@^0.2.0:
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f"
   integrity sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=
 
-os-browserify@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
-  integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
-
 os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
@@ -8685,11 +8644,6 @@ pako@~1.0.2:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
   integrity sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==
-
-pako@~1.0.5:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
-  integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
 
 parallel-transform@^1.1.0:
   version "1.1.0"
@@ -9252,11 +9206,6 @@ process@^0.11.0:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.9.tgz#7bd5ad21aa6253e7da8682264f1e11d11c0318c1"
   integrity sha1-e9WtIapiU+fahoImTx4R0RwDGME=
 
-process@^0.11.10:
-  version "0.11.10"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
-
 process@~0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
@@ -9539,6 +9488,14 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
+random-emoji@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/random-emoji/-/random-emoji-1.0.2.tgz#578298377f56baba45f6ad4797da1a0303321e8c"
+  integrity sha1-V4KYN39WurpF9q1Hl9oaAwMyHow=
+  dependencies:
+    emoji-named-characters "^1.0.2"
+    lodash.shuffle "^4.1.0"
 
 randomatic@^1.1.3:
   version "1.1.6"
@@ -10837,17 +10794,6 @@ stream-http@^2.3.1:
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
-stream-http@^2.7.2:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
-  integrity sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==
-  dependencies:
-    builtin-status-codes "^3.0.0"
-    inherits "^2.0.1"
-    readable-stream "^2.3.6"
-    to-arraybuffer "^1.0.0"
-    xtend "^4.0.0"
-
 stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
@@ -10929,7 +10875,7 @@ string_decoder@^0.10.25, string_decoder@~0.10.x:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
   integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
-string_decoder@^1.0.0, string_decoder@^1.1.1:
+string_decoder@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
   integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
@@ -11304,13 +11250,6 @@ timers-browserify@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.2.tgz#ab4883cf597dcd50af211349a00fbca56ac86b86"
   integrity sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=
-  dependencies:
-    setimmediate "^1.0.4"
-
-timers-browserify@^2.0.4:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"
-  integrity sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   dependencies:
     setimmediate "^1.0.4"
 
@@ -11863,13 +11802,6 @@ util@0.10.3, util@^0.10.3:
   integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
-
-util@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
-  integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
-  dependencies:
-    inherits "2.0.3"
 
 utila@^0.4.0, utila@~0.4:
   version "0.4.0"


### PR DESCRIPTION
Ticket: None

Has breaking changes to public API?: None

#### Description
- Replace `joi` to `joi-browser`
  - `joi` dependent to `net` module from Node.js. But `net` module isn't shim by Webpack.
     It makes to difficult for using `@delirvfx/core` on Browser.
- And fix some typings

#### Annotation to release
None

#### Breaking changes (In delir-core Public API or Expression/p5.js intergration API)
None
