### PR TITLE
Refactor keyframe methods

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.8.0
+#### Breaking changes
+- Refactor `KeyframeCalculator`
+  - Renamed `.calcKeyframeValuesAt` -> `.calcKeyframesAt`
+  - Renamed `.calcKeyframeValueAt` -> `.calcKeyframeAt`
+  - Renamed `.calcKeyFrames` -> `.calcKeyframesInRange`
+  - `.calcKeyframe` now privated
+
 ### 0.7.4
 - #226 Fix plugin's package.json typing
 - #226 Replace `joi` dependency to `joi-browser`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "@delirvfx/core",
-  "version": "0.7.4",
-  "description": "JavaScript VFX Engine",
-  "main": "lib/index.js",
-  "types": "typings/index.d.ts",
-  "author": "Ragg <ragg.devpr@gmail.com>",
-  "license": "MIT",
-  "homepage": "https://github.com/Ragg-/Delir/tree/master/src/delir-core",
-  "scripts": {
-    "prepublishOnly": "rm -rf ./{typings,lib} && tsc --emitDeclarationOnly --declaration --outDir ./typings && tsc --outDir lib"
-  },
-  "devDependencies": {
-    "@delirvfx/core-test-helper": "*",
-    "@types/audiobuffer-to-wav": "1.0.0",
-    "@types/jest": "24.0.15",
-    "@types/joi": "14.3.3",
-    "@types/lodash": "4.14.123",
-    "@types/semver": "6.0.1",
-    "@types/uuid": "3.4.4",
-    "@types/webgl2": "0.0.5",
-    "jest": "24.9.0",
-    "ts-jest": "24.0.2"
-  },
-  "dependencies": {
-    "bezier-easing": "2.1.0",
-    "font-manager": "0.3.0",
-    "joi-browser": "^13.4.0",
-    "lodash": "4.17.13",
-    "p5": "0.9.0",
-    "semver": "6.0.0",
-    "typescript": "3.4.4",
-    "uuid": "3.3.2"
-  }
+    "name": "@delirvfx/core",
+    "version": "0.8.0",
+    "description": "JavaScript VFX Engine",
+    "main": "lib/index.js",
+    "types": "typings/index.d.ts",
+    "author": "Ragg <ragg.devpr@gmail.com>",
+    "license": "MIT",
+    "homepage": "https://github.com/Ragg-/Delir/tree/master/src/delir-core",
+    "scripts": {
+        "prepublishOnly": "rm -rf ./{typings,lib} && tsc --emitDeclarationOnly --declaration --outDir ./typings && tsc --outDir lib"
+    },
+    "devDependencies": {
+        "@delirvfx/core-test-helper": "*",
+        "@types/audiobuffer-to-wav": "1.0.0",
+        "@types/jest": "24.0.15",
+        "@types/joi": "14.3.3",
+        "@types/lodash": "4.14.123",
+        "@types/semver": "6.0.1",
+        "@types/uuid": "3.4.4",
+        "@types/webgl2": "0.0.5",
+        "jest": "24.9.0",
+        "ts-jest": "24.0.2"
+    },
+    "dependencies": {
+        "bezier-easing": "2.1.0",
+        "font-manager": "0.3.0",
+        "joi-browser": "^13.4.0",
+        "lodash": "4.17.13",
+        "p5": "0.9.0",
+        "semver": "6.0.0",
+        "typescript": "3.4.4",
+        "uuid": "3.3.2"
+    }
 }

--- a/packages/core/src/Engine/KeyframeCalcurator.spec.ts
+++ b/packages/core/src/Engine/KeyframeCalcurator.spec.ts
@@ -22,22 +22,18 @@ describe('KeyframeHelper', () => {
       })
 
       it('Before first keyframe', () => {
-        const actual = KeyframeHelper.calcKeyframeValuesAt(0, clipPlacedFrame, mockDesc, sequence).string
+        const actual = KeyframeHelper.calcKeyframesAt(0, clipPlacedFrame, mockDesc, sequence).string
         expect(actual).toBe('ABC')
       })
 
       it('On first keyframe', () => {
-        const actual = KeyframeHelper.calcKeyframeValuesAt(
-          /* first kf position */ 10,
-          clipPlacedFrame,
-          mockDesc,
-          sequence,
-        ).string
+        const actual = KeyframeHelper.calcKeyframesAt(/* first kf position */ 10, clipPlacedFrame, mockDesc, sequence)
+          .string
         expect(actual).toBe('ABC')
       })
 
       it('On before second keyframe', () => {
-        const actual = KeyframeHelper.calcKeyframeValuesAt(
+        const actual = KeyframeHelper.calcKeyframesAt(
           /* before second kf position */ 49,
           clipPlacedFrame,
           mockDesc,
@@ -47,17 +43,13 @@ describe('KeyframeHelper', () => {
       })
 
       it('On second keyframe', () => {
-        const actual = KeyframeHelper.calcKeyframeValuesAt(
-          /* second kf position */ 50,
-          clipPlacedFrame,
-          mockDesc,
-          sequence,
-        ).string
+        const actual = KeyframeHelper.calcKeyframesAt(/* second kf position */ 50, clipPlacedFrame, mockDesc, sequence)
+          .string
         expect(actual).toBe('DEF')
       })
 
       it('On after second keyframe', () => {
-        const actual = KeyframeHelper.calcKeyframeValuesAt(
+        const actual = KeyframeHelper.calcKeyframesAt(
           /* after second kf position */ 51,
           clipPlacedFrame,
           mockDesc,
@@ -67,17 +59,13 @@ describe('KeyframeHelper', () => {
       })
 
       it('On last keyframe', () => {
-        const actual = KeyframeHelper.calcKeyframeValuesAt(
-          /* last kf position */ 100,
-          clipPlacedFrame,
-          mockDesc,
-          sequence,
-        ).string
+        const actual = KeyframeHelper.calcKeyframesAt(/* last kf position */ 100, clipPlacedFrame, mockDesc, sequence)
+          .string
         expect(actual).toBe('XYZ')
       })
 
       it('After last keyframe', () => {
-        const actual = KeyframeHelper.calcKeyframeValuesAt(
+        const actual = KeyframeHelper.calcKeyframesAt(
           /* after last kf position */ 101,
           clipPlacedFrame,
           mockDesc,

--- a/packages/core/src/Engine/KeyframeCalcurator.ts
+++ b/packages/core/src/Engine/KeyframeCalcurator.ts
@@ -17,7 +17,7 @@ export interface KeyframeParamValueSequence {
   [frame: number]: KeyframeValueTypes
 }
 
-export function calcKeyframeValuesAt(
+export function calcKeyframesAt(
   frame: number,
   clipPlacedFrame: number,
   descriptor: TypeDescriptor,
@@ -25,7 +25,7 @@ export function calcKeyframeValuesAt(
 ): { [paramName: string]: KeyframeValueTypes } {
   return descriptor.properties
     .map<[string, KeyframeValueTypes]>(desc => {
-      return [desc.paramName, calcKeyframeValueAt(frame, clipPlacedFrame, desc, keyframes[desc.paramName] || [])]
+      return [desc.paramName, calcKeyframeAt(frame, clipPlacedFrame, desc, keyframes[desc.paramName] || [])]
     })
     .reduce((values, entry) => {
       values[entry[0]] = entry[1]
@@ -33,7 +33,7 @@ export function calcKeyframeValuesAt(
     }, Object.create(null))
 }
 
-export function calcKeyframeValueAt(
+export function calcKeyframeAt(
   frame: number,
   clipPlacedFrame: number,
   desc: AnyParameterTypeDescriptor,
@@ -63,7 +63,7 @@ export function calcKeyframeValueAt(
     case 'ENUM':
       return calcKeyframe(desc, keyframes, clipPlacedFrame, frame, 1, calcEnumKeyFrames)[frame]
     case 'CODE':
-      return calcKeyframe(desc, keyframes, clipPlacedFrame, frame, 1, calcNoAnimatableKeyframes)[frame]
+      return calcKeyframe(desc, keyframes, clipPlacedFrame, frame, 1, calcNonAnimatableKeyframes)[frame]
     // case 'CLIP':
     //     return calcKeyframe(desc, keyframes, clipPlacedFrame, frame, 1, calcNoAnimatable)[frame]
     // case 'PULSE':
@@ -77,7 +77,7 @@ export function calcKeyframeValueAt(
   }
 }
 
-export function calcKeyFrames(
+export function calcKeyframesInRange(
   paramTypes: TypeDescriptor | AnyParameterTypeDescriptor[],
   keyFrames: { [paramName: string]: ReadonlyArray<Keyframe> },
   clipPlacedFrame: number,
@@ -200,7 +200,7 @@ export function calcKeyFrames(
           clipPlacedFrame,
           beginFrame,
           calcFrames,
-          calcNoAnimatableKeyframes,
+          calcNonAnimatableKeyframes,
         )
         break
     }
@@ -209,7 +209,7 @@ export function calcKeyFrames(
   return tables
 }
 
-export function calcKeyframe(
+function calcKeyframe(
   propDesc: AnyParameterTypeDescriptor,
   keyFrameSequense: ReadonlyArray<Keyframe>,
   clipPlacedFrame: number,
@@ -224,7 +224,7 @@ export function calcKeyframe(
   const table: KeyframeParamValueSequence = {}
 
   for (let frame = beginFrame, end = beginFrame + calcFrames; frame <= end; frame++) {
-    const activeKeyFrame: KeyFrameLink<KeyframeValueTypes> | null = _activeKeyFrameOfFrame(
+    const activeKeyFrame: KeyFrameLink<KeyframeValueTypes> | null = activeKeyFrameOfFrame(
       linkedSequense,
       clipPlacedFrame,
       frame,
@@ -292,7 +292,7 @@ function _buildLinkedKeyFrame(orderedKeyFrameSeq: Keyframe[]): KeyFrameLink<Keyf
   return linked
 }
 
-function _activeKeyFrameOfFrame(
+function activeKeyFrameOfFrame(
   linkedKeyFrameSeq: KeyFrameLink<KeyframeValueTypes>[],
   clipPlacedFrame: number,
   frame: number,
@@ -438,7 +438,7 @@ function calcAssetKeyFrames(rate: number, frame: number, keyFrameLink: KeyFrameL
     : (keyFrameLink.active!.value as AssetPointer)
 }
 
-function calcNoAnimatableKeyframes(rate: number, frame: number, keyFrameLink: KeyFrameLink<any>): any {
+function calcNonAnimatableKeyframes(rate: number, frame: number, keyFrameLink: KeyFrameLink<any>): any {
   return keyFrameLink.active.value
 }
 

--- a/packages/core/src/Engine/ParametersTable.ts
+++ b/packages/core/src/Engine/ParametersTable.ts
@@ -35,7 +35,7 @@ export class ParametersTable {
     const assetPramNames = paramTypes.properties.filter(prop => prop.type === 'ASSET').map(prop => prop.paramName)
 
     // Calculate initial parameters
-    const rawRendererInitParam = KeyframeCalcurator.calcKeyframeValuesAt(0, clip.placedFrame, paramTypes, keyframes)
+    const rawRendererInitParam = KeyframeCalcurator.calcKeyframesAt(0, clip.placedFrame, paramTypes, keyframes)
     const initialParams: RealParameterValues = {
       ...(rawRendererInitParam as any),
     }
@@ -47,7 +47,7 @@ export class ParametersTable {
     })
 
     // Calculate look up table
-    const rawKeyframeLUT = KeyframeCalcurator.calcKeyFrames(
+    const rawKeyframeLUT = KeyframeCalcurator.calcKeyframesInRange(
       paramTypes,
       keyframes,
       clip.placedFrame,

--- a/packages/delir/src/views/KeyframeEditor/KeyframeEditor.tsx
+++ b/packages/delir/src/views/KeyframeEditor/KeyframeEditor.tsx
@@ -178,7 +178,7 @@ export const KeyframeEditor = withFleurContext(
                   activeParamDescriptor.type === 'CODE' &&
                   (() => {
                     const value = activeClip
-                      ? Delir.KeyframeCalcurator.calcKeyframeValueAt(
+                      ? Delir.KeyframeCalcurator.calcKeyframeAt(
                           editor.currentPreviewFrame,
                           activeClip.placedFrame,
                           activeParamDescriptor,
@@ -242,7 +242,7 @@ export const KeyframeEditor = withFleurContext(
 
         return this.clipParamDescriptors.map(desc => {
           const value = activeClip
-            ? Delir.KeyframeCalcurator.calcKeyframeValueAt(
+            ? Delir.KeyframeCalcurator.calcKeyframeAt(
                 editor.currentPreviewFrame,
                 activeClip.placedFrame,
                 desc,
@@ -426,7 +426,7 @@ export const KeyframeEditor = withFleurContext(
                   effect.expressions[desc.paramName] && effect.expressions[desc.paramName].code !== ''
 
                 const value = activeClip
-                  ? Delir.KeyframeCalcurator.calcKeyframeValueAt(
+                  ? Delir.KeyframeCalcurator.calcKeyframeAt(
                       editor.currentPreviewFrame,
                       activeClip.placedFrame,
                       desc,

--- a/packages/delir/src/views/KeyframeEditor/KeyframeMediator.tsx
+++ b/packages/delir/src/views/KeyframeEditor/KeyframeMediator.tsx
@@ -48,7 +48,7 @@ export const KeyframeMediator = ({
   onModifyKeyframe,
 }: OwnProps) => {
   const { activeComp } = useStore([EditorStore], getStore => ({
-    activeComp: getActiveComp()(getStore),
+    activeComp: getActiveComp(getStore),
   }))
 
   return (


### PR DESCRIPTION
Ticket: None

Has breaking changes to public API?: Yes

#### Description
- KeyframeCalculatorの各メソッドの違いが分かりづらかったのでメソッド名を変更した

#### Annotation to release

#### Breaking changes (In delir-core Public API or Expression/p5.js intergration API)
- See CHANGELOG
